### PR TITLE
Update broken image url for ethereum/rinkeby networks

### DIFF
--- a/packages/hooks/src/useWeb3.ts
+++ b/packages/hooks/src/useWeb3.ts
@@ -37,14 +37,14 @@ const defaultNetworkMetadata = {
   1: {
     chainName: "Ethereum",
     iconUrl:
-      "https://ethereum.org/static/4b5288012dc4b32ae7ff21fccac98de1/31987/eth-diamond-black-gray.png",
+      "https://gateway.pinata.cloud/ipfs/QmQy3qKSfhxgE4xs9YJM6bG5f5cTJi9wXVFgroqPTbF2T9",
     symbol: "ETH",
     isTestnet: false,
   },
   4: {
     chainName: "Rinkeby",
     iconUrl:
-      "https://ethereum.org/static/4b5288012dc4b32ae7ff21fccac98de1/31987/eth-diamond-black-gray.png",
+      "https://gateway.pinata.cloud/ipfs/QmQy3qKSfhxgE4xs9YJM6bG5f5cTJi9wXVFgroqPTbF2T9",
     symbol: "ETH",
     isTestnet: true,
   },


### PR DESCRIPTION
Replaced the broken `iconUrl` for Ethereum and Rinkeby. The updated image found [here](https://ethereum.org/static/4b5288012dc4b32ae7ff21fccac98de1/448ee/eth-diamond-black-gray.webp) was huge, so thought I would just downsize it a bit and pin it with pinata. Happy to change it to the original if you prefer it though. 

Pinata Img Preview:

![ethereum-diamond](https://gateway.pinata.cloud/ipfs/QmQy3qKSfhxgE4xs9YJM6bG5f5cTJi9wXVFgroqPTbF2T9)

