### PR TITLE
Add regenerator-runtime import to packages/hooks

### DIFF
--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -37,6 +37,7 @@
     "@web3-react/magic-connector": "^6.1.9",
     "@web3-react/walletconnect-connector": "^6.2.8",
     "@web3-react/walletlink-connector": "^6.2.8",
+    "regenerator-runtime": "^0.13.9",
     "tiny-invariant": "^1.2.0"
   }
 }

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,3 +1,5 @@
+import "regenerator-runtime/runtime.js";
+
 export * from "./useSwitchNetwork";
 export * from "./useWeb3";
 export * from "./Web3Provider";

--- a/yarn.lock
+++ b/yarn.lock
@@ -14257,7 +14257,7 @@ regenerator-runtime@^0.11.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
-regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
+regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7, regenerator-runtime@^0.13.9:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==


### PR DESCRIPTION
Fixes #42 

This PR fixes the `ReferenceError: regeneratorRuntime is not defined` error when using wallet connect in NextJS. 

It imports `regenerator-runtime/runtime.js` in the `useConnectWallet` hook, which resolves the error.

To verify the fix, you can do the following. There's probably an easier way but I'm not familiar with `preconstruct`. 

- Clone my fork: `git clone git@github.com:mcintyre94/ui.git`
- Check out my branch: `cd ui && git checkout cm-fix-regenerator-runtime`
- Build + run the Next example: `cd examples/next && npm install && npm run dev` 
- Visit http://localhost:3000/connect + observe the error
- Build the packages: `cd - && yarn && yarn build`
- Verify that `regenerator-runtime` is now in the built hooks package: 
```
$ grep "regenerator-runtime" packages/hooks/dist/3rdweb-hooks.cjs.dev.js
require('regenerator-runtime/runtime.js');
```
- Replace the `@3rdweb/hooks/dist` in example/next/node_modules with the newly built one: `rm -rf examples/next/node_modules/@3rdweb/hooks/dist && mv packages/hooks/dist examples/next/node_modules/@3rdweb/hooks` 
- Run the example/next again: `cd example/next && npm run dev`
- Visit http://localhost:3000/connect + see it works! 🎉 

![image](https://user-images.githubusercontent.com/1711350/148811782-3e278ba5-148b-45ab-8fc4-cbf51f05ce91.png)
